### PR TITLE
Add support for installation via composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .xref
 tmp
+/vendor/

--- a/XRef.class.php
+++ b/XRef.class.php
@@ -1226,7 +1226,7 @@ class XRef {
     public static function showHelpScreen($tool_name, $usage_string = null) {
         global $argv;
         if (!$usage_string) {
-            $usage_string = "$argv[0] [options]";
+            $usage_string = basename($argv[0]) . " [options]";
         }
 
         echo "$tool_name, v. " . self::version() . "\n";

--- a/XRef.class.php
+++ b/XRef.class.php
@@ -105,6 +105,13 @@ class XRef {
 
     /** constructor */
     public function __construct() {
+        if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+            // Installed via composer (standalone)
+            require_once __DIR__ . '/vendor/autoload.php';
+        } elseif (dirname(dirname(__DIR__)) . '/autoload.php') {
+            // Installed via composer (as dependency)
+            require_once dirname(dirname(__DIR__)) . '/autoload.php';
+        }
         spl_autoload_register(array($this, "autoload"), true);
 
         // compat mode

--- a/bin-scripts/xref-lint.php
+++ b/bin-scripts/xref-lint.php
@@ -34,9 +34,10 @@ try {
 }
 
 if (XRef::needHelp()) {
+    $program = basename($argv[0]);
     XRef::showHelpScreen(
         "xref-lint - tool to find problems in PHP source code",
-        "$argv[0] [options] [files to check]"
+        "$program [options] [files to check]"
     );
     exit(1);
 }

--- a/bin/git-xref-lint
+++ b/bin/git-xref-lint
@@ -12,11 +12,13 @@
 ## @licence http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
 ##
 
-if [ "@php_dir@" == @"php_dir@" ]; then 
-	SCRIPTDIR=$(dirname $0)/../bin-scripts
-else
-	SCRIPTDIR="@php_dir@/XRef/bin-scripts"
-fi
+for dir in '@php_dir@/XRef/bin-scripts' $(dirname $0)/../bin-scripts $(dirname $0)/../vendor/gariev/xref/bin-scripts
+do
+    if [ -d "$dir" ]; then
+        SCRIPTDIR="$dir"
+        break
+    fi
+done
 
 if [ "@php_bin@" == @"php_bin@" ]; then 
 	PHP=php

--- a/bin/xref-ci
+++ b/bin/xref-ci
@@ -10,11 +10,13 @@
 ## @licence http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
 ##
 
-if [ "@php_dir@" == @"php_dir@" ]; then
-    SCRIPTDIR=$(dirname $0)/../bin-scripts
-else
-    SCRIPTDIR="@php_dir@/XRef/bin-scripts"
-fi
+for dir in '@php_dir@/XRef/bin-scripts' $(dirname $0)/../bin-scripts $(dirname $0)/../vendor/gariev/xref/bin-scripts
+do
+    if [ -d "$dir" ]; then
+        SCRIPTDIR="$dir"
+        break
+    fi
+done
 
 if [ "@php_bin@" == @"php_bin@" ]; then
     PHP=php

--- a/bin/xref-doc
+++ b/bin/xref-doc
@@ -10,11 +10,13 @@
 ## @licence http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
 ##
 
-if [ "@php_dir@" == @"php_dir@" ]; then
-	SCRIPTDIR=$(dirname $0)/../bin-scripts
-else
-	SCRIPTDIR="@php_dir@/XRef/bin-scripts"
-fi
+for dir in '@php_dir@/XRef/bin-scripts' $(dirname $0)/../bin-scripts $(dirname $0)/../vendor/gariev/xref/bin-scripts
+do
+    if [ -d "$dir" ]; then
+        SCRIPTDIR="$dir"
+        break
+    fi
+done
 
 if [ "@php_bin@" == @"php_bin@" ]; then
 	PHP=php

--- a/bin/xref-lint
+++ b/bin/xref-lint
@@ -10,11 +10,13 @@
 ## @licence http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
 ##
 
-if [ "@php_dir@" == @"php_dir@" ]; then
-    SCRIPTDIR=$(dirname $0)/../bin-scripts
-else
-    SCRIPTDIR="@php_dir@/XRef/bin-scripts"
-fi
+for dir in '@php_dir@/XRef/bin-scripts' $(dirname $0)/../bin-scripts $(dirname $0)/../vendor/gariev/xref/bin-scripts
+do
+    if [ -d "$dir" ]; then
+        SCRIPTDIR="$dir"
+        break
+    fi
+done
 
 if [ "@php_bin@" == @"php_bin@" ]; then
     PHP=php

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "gariev/xref",
+    "description": "xref-lint",
+    "license": "Apache-2.0",
+    "require": {
+        "smarty/smarty": "3.1.*"
+    },
+    "bin": [
+        "bin/xref-ci",
+        "bin/git-xref-lint",
+        "bin/xref-doc",
+        "bin/xref-lint"
+    ],
+    "authors": [
+        {
+            "name": "gariev",
+            "email": "gariev@hotmail.com"
+        }
+    ]
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,69 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+    ],
+    "hash": "acbae113e03a40a83a95864bc7d3ef44",
+    "packages": [
+        {
+            "name": "smarty/smarty",
+            "version": "v3.1.16",
+            "source": {
+                "type": "svn",
+                "url": "http://smarty-php.googlecode.com/svn",
+                "reference": "/tags/v3.1.16/@4802"
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "distribution/libs/Smarty.class.php",
+                    "distribution/libs/SmartyBC.class.php",
+                    "distribution/libs/sysplugins/smarty_security.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Monte Ohrt",
+                    "email": "monte@ohrt.com"
+                },
+                {
+                    "name": "Uwe Tews",
+                    "email": "uwe.tews@googlemail.com"
+                },
+                {
+                    "name": "Rodney Rehm",
+                    "email": "rodney.rehm@medialize.de"
+                }
+            ],
+            "description": "Smarty - the compiling PHP template engine",
+            "homepage": "http://www.smarty.net",
+            "keywords": [
+                "templating"
+            ],
+            "time": "2013-12-17 16:56:58"
+        }
+    ],
+    "packages-dev": [
+
+    ],
+    "aliases": [
+
+    ],
+    "minimum-stability": "stable",
+    "stability-flags": [
+
+    ],
+    "platform": [
+
+    ],
+    "platform-dev": [
+
+    ]
+}


### PR DESCRIPTION
For teams that want to adopt composer and xref-lint, declaring a
dependency on xref-lint (esp. using "require-dev" or "suggest")
would make it easier for developers on the team to adopt.
